### PR TITLE
The `Polarity=Neg` feature is not used together with `PronType=Neg` (German _kein_).

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,10 @@ For language IDs:
 ```
 
 # Changelog
+
+* 2023-05-15 v2.12
+  * The `Polarity=Neg` feature is not used together with `PronType=Neg` (German _kein_).
+
 * 2021-11-15 v2.9
   * The `LangID` feature is renamed as `CSID`, and the `Lang` feature is introduced.
   

--- a/qtd_sagt-ud-dev.conllu
+++ b/qtd_sagt-ud-dev.conllu
@@ -803,7 +803,7 @@
 8	detektif	detektif	NOUN	_	Case=Nom|Number=Sing	7	obj	_	CSID=TR|Lang=tr
 9	obwohl	obwohl	SCONJ	_	_	13	mark	_	CSID=DE|Lang=de
 10	sie	sie	PRON	_	Case=Nom|Gender=Fem|Number=Sing|Person=3|PronType=Prs	13	nsubj	_	CSID=DE|Lang=de
-11	keine	kein	DET	_	Case=Acc|Definite=Ind|Gender=Fem|Number=Sing|Polarity=Neg|PronType=Neg	13	det	_	CSID=DE|Lang=de
+11	keine	kein	DET	_	Case=Acc|Definite=Ind|Gender=Fem|Number=Sing|PronType=Neg	13	det	_	CSID=DE|Lang=de
 12	De--	Detektivin	NOUN	_	Case=Acc|Gender=Fem|Number=Sing|Typo=Yes	13	reparandum	_	CSID=DE|Lang=de|CorrectForm=Detektivin
 13	Detektivin	Detektivin	NOUN	_	Case=Acc|Gender=Fem|Number=Sing	7	conj	_	CSID=DE|Lang=de
 14	ist	sein	AUX	_	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	13	cop	_	CSID=DE|Lang=de|SpaceAfter=No
@@ -854,7 +854,7 @@
 9	es	es	PRON	_	Case=Nom|Gender=Neut|Number=Sing|Person=3|PronType=Prs	0	root	_	CSID=DE|Lang=de
 10	ist	sein	AUX	_	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	9	cop	_	CSID=DE|Lang=de
 11	eigentlich	eigentlich	ADV	_	_	9	advmod	_	CSID=DE|Lang=de
-12	kein	kein	DET	_	Case=Acc|Definite=Ind|Gender=Neut|Number=Sing|Polarity=Neg|PronType=Neg	13	det	_	CSID=DE|Lang=de
+12	kein	kein	DET	_	Case=Acc|Definite=Ind|Gender=Neut|Number=Sing|PronType=Neg	13	det	_	CSID=DE|Lang=de
 13	Problem	Problem	NOUN	_	Case=Nom|Gender=Neut|Number=Sing	9	nsubj	_	CSID=DE|Lang=de
 14	für	für	ADP	_	_	15	case	_	CSID=DE|Lang=de
 15	mich	ich	PRON	_	Case=Acc|Number=Sing|Person=1|PronType=Prs	9	obl	_	CSID=DE|Lang=de
@@ -1923,7 +1923,7 @@
 9	Fast	Fast	PROPN	_	_	6	ccomp	_	CSID=DE|Lang=de
 10	Food	Food	PROPN	_	Case=Nom|Gender=Neut|Number=Sing	9	flat	_	CSID=DE|Lang=de
 11	so	so	ADV	_	_	13	advmod	_	CSID=DE|Lang=de
-12	keine	kein	DET	_	Case=Acc|Definite=Ind|Gender=Fem|Number=Sing|Polarity=Neg|PronType=Neg	13	det	_	CSID=DE|Lang=de
+12	keine	kein	DET	_	Case=Acc|Definite=Ind|Gender=Fem|Number=Sing|PronType=Neg	13	det	_	CSID=DE|Lang=de
 13	Ahnung	Ahnung	NOUN	_	Case=Acc|Gender=Fem|Number=Sing	6	discourse	_	CSID=DE|Lang=de
 14	so	so	ADV	_	_	16	advmod	_	CSID=DE|Lang=de
 15	ein	ein	DET	_	Case=Nom|Definite=Ind|Gender=Masc|Number=Sing|PronType=Art	16	det	_	CSID=DE|Lang=de
@@ -2370,7 +2370,7 @@
 14	gewisse	gewiss	ADJ	_	Case=Acc|Gender=Fem|Number=Plur	15	amod	_	CSID=DE|Lang=de
 15	Menge	Menge	NOUN	_	Case=Acc|Gender=Fem|Number=Sing	18	nmod	_	CSID=DE|Lang=de
 16	an	an	ADP	_	_	18	case	_	CSID=DE|Lang=de
-17	keine	kein	DET	_	Case=Nom|Definite=Ind|Gender=Fem|Number=Sing|Polarity=Neg|PronType=Neg	18	det	_	CSID=DE|Lang=de
+17	keine	kein	DET	_	Case=Nom|Definite=Ind|Gender=Fem|Number=Sing|PronType=Neg	18	det	_	CSID=DE|Lang=de
 18	Ahnung	Ahnung	NOUN	_	Case=Nom|Gender=Fem|Number=Sing	23	obl	_	CSID=DE|Lang=de
 19	was	was	PRON	_	Case=Acc|Number=Sing|PronType=Rel	23	obj	_	CSID=DE|Lang=de
 20	ähm	ähm	INTJ	_	_	23	discourse	_	CSID=DE|Lang=de
@@ -3637,7 +3637,7 @@
 11	ich	ich	PRON	_	Case=Nom|Number=Sing|Person=1|PronType=Prs	12	nsubj	_	CSID=DE|Lang=de
 12	hatte	haben	VERB	_	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	7	ccomp	_	CSID=DE|Lang=de
 13	überhaupt	überhaupt	ADV	_	_	12	advmod	_	CSID=DE|Lang=de
-14	keine	kein	DET	_	Case=Acc|Definite=Ind|Gender=Fem|Number=Sing|Polarity=Neg|PronType=Neg	15	det	_	CSID=DE|Lang=de
+14	keine	kein	DET	_	Case=Acc|Definite=Ind|Gender=Fem|Number=Sing|PronType=Neg	15	det	_	CSID=DE|Lang=de
 15	Schwierigkeiten	Schwierigkeit	NOUN	_	Case=Acc|Gender=Fem|Number=Plur	12	obj	_	CSID=DE|Lang=de
 16	oder	oder	CCONJ	_	_	20	cc	_	CSID=DE|Lang=de
 17	so	so	ADV	_	_	20	advmod	_	CSID=DE|Lang=de
@@ -4023,7 +4023,7 @@
 21	Polizist	Polizist	NOUN	_	Case=Nom|Gender=Masc|Number=Sing	19	conj	_	CSID=DE|Lang=de
 22	oder	oder	CCONJ	_	_	25	cc	_	CSID=DE|Lang=de
 23	äh	äh	INTJ	_	_	25	discourse	_	CSID=DE|Lang=de
-24	keine	kein	DET	_	Case=Acc|Definite=Ind|Gender=Fem|Number=Sing|Polarity=Neg|PronType=Neg	25	det	_	CSID=DE|Lang=de
+24	keine	kein	DET	_	Case=Acc|Definite=Ind|Gender=Fem|Number=Sing|PronType=Neg	25	det	_	CSID=DE|Lang=de
 25	Ahnung	Ahnung	NOUN	_	Case=Acc|Gender=Fem|Number=Sing	19	conj	_	CSID=DE|Lang=de|SpaceAfter=No
 26	.	.	PUNCT	_	_	9	punct	_	CSID=OTHER
 
@@ -5640,7 +5640,7 @@
 9	du	du	PRON	_	Case=Nom|Number=Sing|Person=2|PronType=Prs	13	nsubj	_	CSID=DE|Lang=de
 10	musst	müssen	AUX	_	Mood=Ind|Number=Sing|Person=2|Tense=Pres	13	aux	_	CSID=DE|Lang=de
 11	aber	aber	CCONJ	_	_	13	cc	_	CSID=DE|Lang=de
-12	keins	kein	PRON	_	Case=Acc|Gender=Neut|Number=Sing|Polarity=Neg|PronType=Neg	13	obj	_	CSID=DE|Lang=de
+12	keins	kein	PRON	_	Case=Acc|Gender=Neut|Number=Sing|PronType=Neg	13	obj	_	CSID=DE|Lang=de
 13	haben	haben	VERB	_	VerbForm=Inf	5	parataxis	_	CSID=DE|Lang=de|SpaceAfter=No
 14	.	.	PUNCT	_	_	5	punct	_	CSID=OTHER
 
@@ -5762,7 +5762,7 @@
 6	sich	er|es|sie	PRON	_	Case=Dat|Number=Plur|Person=3|PronType=Prs	5	iobj	_	CSID=DE|Lang=de
 7	da	da	ADV	_	_	5	advmod	_	CSID=DE|Lang=de
 8	gar	gar	ADV	_	_	9	advmod	_	CSID=DE|Lang=de
-9	keine	kein	PRON	_	Case=Nom|Gender=Fem|Number=Sing|Polarity=Neg|PronType=Neg	5	obj	_	CSID=DE|Lang=de
+9	keine	kein	PRON	_	Case=Nom|Gender=Fem|Number=Sing|PronType=Neg	5	obj	_	CSID=DE|Lang=de
 10	so	so	ADV	_	_	5	discourse	_	CSID=DE|Lang=de|SpaceAfter=No
 11	.	.	PUNCT	_	_	5	punct	_	CSID=OTHER
 
@@ -6044,7 +6044,7 @@
 50	du	du	PRON	_	Case=Nom|Number=Sing|Person=2|PronType=Prs	55	nsubj	_	CSID=DE|Lang=de
 51	ja	ja	ADV	_	_	55	advmod	_	CSID=DE|Lang=de
 52	auch	auch	ADV	_	_	55	advmod	_	CSID=DE|Lang=de
-53	kein	kein	DET	_	Case=Nom|Definite=Ind|Gender=Neut|Number=Sing|Polarity=Neg|PronType=Neg	54	det	_	CSID=DE|Lang=de
+53	kein	kein	DET	_	Case=Nom|Definite=Ind|Gender=Neut|Number=Sing|PronType=Neg	54	det	_	CSID=DE|Lang=de
 54	Englisch	Englisch	PROPN	_	Case=Acc|Gender=Neut|Number=Sing	55	obj	_	CSID=DE|Lang=de
 55	sprechen	sprechen	VERB	_	VerbForm=Inf	40	conj	_	CSID=DE|Lang=de
 56	oder	oder	CCONJ	_	_	59	cc	_	CSID=DE|Lang=de
@@ -7048,7 +7048,7 @@
 13	man	man	PRON	_	Case=Nom|Number=Sing|PronType=Ind	1	reparandum	_	CSID=DE|Lang=de
 14	so	so	ADV	_	_	1	reparandum	_	CSID=DE|Lang=de|SpaceAfter=No
 15	,	,	PUNCT	_	_	17	punct	_	CSID=OTHER
-16	keine	kein	DET	_	Case=Acc|Definite=Ind|Gender=Fem|Number=Sing|Polarity=Neg|PronType=Neg	17	det	_	CSID=DE|Lang=de
+16	keine	kein	DET	_	Case=Acc|Definite=Ind|Gender=Fem|Number=Sing|PronType=Neg	17	det	_	CSID=DE|Lang=de
 17	Ahnung	Ahnung	NOUN	_	Case=Acc|Gender=Fem|Number=Sing	1	parataxis:discourse	_	CSID=DE|Lang=de
 18	so	so	ADV	_	_	17	advmod	_	CSID=DE|Lang=de|SpaceAfter=No
 19	,	,	PUNCT	_	_	23	punct	_	CSID=OTHER
@@ -9818,7 +9818,7 @@
 23	bitte	bitte	ADV	_	_	22	advmod	_	CSID=DE|Lang=de
 24	ich	ich	PRON	_	Case=Nom|Number=Sing|Person=1|PronType=Prs	25	nsubj	_	CSID=DE|Lang=de
 25	habe	haben	VERB	_	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	19	ccomp	_	CSID=DE|Lang=de
-26	keine	kein	DET	_	Case=Acc|Definite=Ind|Gender=Fem|Number=Sing|Polarity=Neg|PronType=Neg	27	det	_	CSID=DE|Lang=de
+26	keine	kein	DET	_	Case=Acc|Definite=Ind|Gender=Fem|Number=Sing|PronType=Neg	27	det	_	CSID=DE|Lang=de
 27	Lust	Lust	NOUN	_	Case=Acc|Gender=Fem|Number=Sing	25	obj	_	CSID=DE|Lang=de
 28	darauf	darauf	ADV	_	_	27	nmod	_	CSID=DE|Lang=de|SpaceAfter=No
 29	.	.	PUNCT	_	_	9	punct	_	CSID=OTHER
@@ -13116,7 +13116,7 @@
 24	ama	ama	CCONJ	_	_	26	cc	_	CSID=TR|Lang=tr
 25	ich	ich	PRON	_	Case=Nom|Number=Sing|Person=1|PronType=Prs	26	nsubj	_	CSID=DE|Lang=de
 26	habe	haben	VERB	_	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	21	conj	_	CSID=DE|Lang=de
-27	keine	kein	PRON	_	Case=Acc|Gender=Fem|Number=Sing|Polarity=Neg|PronType=Neg	28	nmod	_	CSID=DE|Lang=de
+27	keine	kein	PRON	_	Case=Acc|Gender=Fem|Number=Sing|PronType=Neg	28	nmod	_	CSID=DE|Lang=de
 28	Zeit	Zeit	NOUN	_	Case=Acc|Gender=Fem|Number=Sing	26	obj	_	CSID=DE|Lang=de
 29	dafür	dafür	ADV	_	_	28	advmod	_	CSID=DE|Lang=de
 30	çok	çok	ADV	_	_	32	advmod	_	CSID=TR|Lang=tr
@@ -15546,7 +15546,7 @@
 3	öğretir	öğret	VERB	_	Aspect=Hab|Evident=Fh|Mood=Gen|Number=Sing|Person=3|Tense=Pres	0	root	_	CSID=TR|Lang=tr
 4	o	o	DET	_	Definite=Def	5	det	_	CSID=TR|Lang=tr
 5	zaman	zaman	NOUN	_	Case=Nom|Number=Sing	3	obl	_	CSID=TR|Lang=tr
-6	keine	kein	PRON	_	Case=Nom|Gender=Fem|Number=Sing|Polarity=Neg|PronType=Neg	7	nmod	_	CSID=DE|Lang=de
+6	keine	kein	PRON	_	Case=Nom|Gender=Fem|Number=Sing|PronType=Neg	7	nmod	_	CSID=DE|Lang=de
 7	Ahnung	Ahnung	NOUN	_	Case=Nom|Gender=Fem|Number=Sing	3	parataxis	_	CSID=DE|Lang=de|SpaceAfter=No
 8	,	,	PUNCT	_	_	9	punct	_	CSID=OTHER
 9	wie	wie	ADV	_	_	7	acl	_	CSID=DE|Lang=de

--- a/qtd_sagt-ud-test.conllu
+++ b/qtd_sagt-ud-test.conllu
@@ -2474,7 +2474,7 @@
 
 # sent_id = TRDE-CS-C20-0034
 # text = Keine Ahnung irgendwie Kellogs bilmem ne ya da küçük bir Brötchen oder so.
-1	Keine	kein	DET	_	Case=Nom|Definite=Ind|Gender=Fem|Number=Sing|Polarity=Neg|PronType=Neg	2	det	_	CSID=DE|Lang=de
+1	Keine	kein	DET	_	Case=Nom|Definite=Ind|Gender=Fem|Number=Sing|PronType=Neg	2	det	_	CSID=DE|Lang=de
 2	Ahnung	Ahnung	NOUN	_	Case=Nom|Gender=Fem|Number=Sing	5	obl	_	CSID=DE|Lang=de
 3	irgendwie	irgendwie	ADV	_	_	5	advmod	_	CSID=DE|Lang=de
 4	Kellogs	Kellogs	PROPN	_	Case=Nom|Gender=Fem|Number=Sing	5	obj	_	CSID=DE|Lang=de
@@ -2573,7 +2573,7 @@
 7	so	so	ADV	_	_	8	advmod	_	CSID=DE|Lang=de
 8	machen	machen	VERB	_	VerbForm=Inf	0	root	_	CSID=DE|Lang=de
 9	kann	können	AUX	_	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	8	aux	_	CSID=DE|Lang=de
-10	keine	kein	DET	_	Case=Nom|Definite=Ind|Gender=Fem|Number=Sing|Polarity=Neg|PronType=Neg	11	det	_	CSID=DE|Lang=de
+10	keine	kein	DET	_	Case=Nom|Definite=Ind|Gender=Fem|Number=Sing|PronType=Neg	11	det	_	CSID=DE|Lang=de
 11	Ahnung	Ahnung	NOUN	_	Case=Nom|Gender=Fem|Number=Sing	8	parataxis:discourse	_	CSID=DE|Lang=de
 12	Kartoffeln	Kartoffel	NOUN	_	Case=Acc|Gender=Fem|Number=Plur	8	obj	_	CSID=DE|Lang=de
 13	oder	oder	CCONJ	_	_	14	cc	_	CSID=DE|Lang=de
@@ -2727,7 +2727,7 @@
 23	so	so	ADV	_	_	16	advmod	_	CSID=DE|Lang=de
 24	Süßigkeiten	Süßigkeiten	NOUN	_	Case=Acc|Gender=Fem|Number=Plur	16	obj	_	CSID=DE|Lang=de
 25	oder	oder	CCONJ	_	_	27	cc	_	CSID=DE|Lang=de
-26	keine	kein	DET	_	Case=Acc|Definite=Ind|Gender=Fem|Number=Sing|Polarity=Neg|PronType=Neg	27	det	_	CSID=DE|Lang=de
+26	keine	kein	DET	_	Case=Acc|Definite=Ind|Gender=Fem|Number=Sing|PronType=Neg	27	det	_	CSID=DE|Lang=de
 27	Ahnung	Ahnung	NOUN	_	Case=Acc|Gender=Fem|Number=Sing	24	conj	_	CSID=DE|Lang=de|SpaceAfter=No
 28	.	.	PUNCT	_	_	2	punct	_	CSID=OTHER
 
@@ -3865,7 +3865,7 @@
 25	man	man	PRON	_	Case=Nom|Number=Sing|PronType=Ind	26	nsubj	_	CSID=DE|Lang=de
 26	hatte	haben	VERB	_	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	23	dislocated	_	CSID=DE|Lang=de|DislocateHead=22
 27	gar	gar	ADV	_	_	28	advmod	_	CSID=DE|Lang=de
-28	keinen	kein	DET	_	Case=Acc|Definite=Ind|Gender=Masc|Number=Sing|Polarity=Neg|PronType=Neg	29	det	_	CSID=DE|Lang=de
+28	keinen	kein	DET	_	Case=Acc|Definite=Ind|Gender=Masc|Number=Sing|PronType=Neg	29	det	_	CSID=DE|Lang=de
 29	Überblick	Überblick	NOUN	_	Case=Acc|Gender=Masc|Number=Sing	26	obj	_	CSID=DE|Lang=de
 30	mehr	mehr	ADV	_	_	26	advmod	_	CSID=DE|Lang=de
 31	hani	hani	ADV	_	_	33	advmod	_	CSID=TR|Lang=tr
@@ -4070,7 +4070,7 @@
 1	Hani	hani	ADV	_	_	3	advmod	_	CSID=TR|Lang=tr
 2	ich	ich	PRON	_	Case=Nom|Gender=Neut|Number=Sing|Person=1|PronType=Prs	3	nsubj	_	CSID=DE|Lang=de
 3	kann	können	VERB	_	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	_	CSID=DE|Lang=de
-4	kein	kein	DET	_	Case=Acc|Definite=Ind|Gender=Neut|Number=Sing|Polarity=Neg|PronType=Neg	5	det	_	CSID=DE|Lang=de
+4	kein	kein	DET	_	Case=Acc|Definite=Ind|Gender=Neut|Number=Sing|PronType=Neg	5	det	_	CSID=DE|Lang=de
 5	Kleid	Kleid	NOUN	_	Case=Acc|Gender=Neut|Number=Sing	3	obj	_	CSID=DE|Lang=de
 6	davon	davon	ADV	_	_	3	advmod	_	CSID=DE|Lang=de
 7	hani	hani	ADV	_	_	12	advmod	_	CSID=TR|Lang=tr
@@ -4217,7 +4217,7 @@
 8	will	wollen	AUX	_	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	15	aux	_	CSID=DE|Lang=de
 9	jetzt	jetzt	ADV	_	_	15	advmod	_	CSID=DE|Lang=de
 10	auch	auch	ADV	_	_	15	advmod	_	CSID=DE|Lang=de
-11	kein	kein	DET	_	Case=Acc|Definite=Ind|Gender=Neut|Number=Sing|Polarity=Neg|PronType=Neg	14	det	_	CSID=DE|Lang=de
+11	kein	kein	DET	_	Case=Acc|Definite=Ind|Gender=Neut|Number=Sing|PronType=Neg	14	det	_	CSID=DE|Lang=de
 12	Prinzessen--	Prinzessinenkleid	NOUN	_	Case=Acc|Gender=Neut|Number=Sing|Typo=Yes	14	reparandum	_	CSID=DE|Lang=de|CorrectForm=Prinzessinenkleid
 13	ähm	ähm	INTJ	_	_	15	discourse	_	CSID=DE|Lang=de
 14	Brautkleid	Brautkleid	NOUN	_	Case=Acc|Gender=Neut|Number=Sing	15	obj	_	CSID=DE|Lang=de
@@ -6818,7 +6818,7 @@
 2	zaten	zaten	ADV	_	_	3	advmod	_	CSID=TR|Lang=tr
 3	da	da	ADV	_	_	0	root	_	CSID=DE|Lang=de
 4	ist	sein	AUX	_	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	3	cop	_	CSID=DE|Lang=de
-5	kein	kein	DET	_	Case=Acc|Definite=Ind|Gender=Masc|Number=Sing|Polarity=Neg|PronType=Neg	7	det	_	CSID=DE|Lang=de
+5	kein	kein	DET	_	Case=Acc|Definite=Ind|Gender=Masc|Number=Sing|PronType=Neg	7	det	_	CSID=DE|Lang=de
 6	großer	groß	ADJ	_	Case=Acc|Gender=Fem|Number=Sing	7	amod	_	CSID=DE|Lang=de
 7	Unterschied	Unterschied	NOUN	_	Case=Nom|Gender=Masc|Number=Sing	3	nsubj	_	CSID=DE|Lang=de
 8	galiba	galiba	ADV	_	_	3	advmod	_	CSID=TR|Lang=tr|SpaceAfter=No
@@ -9068,7 +9068,7 @@
 
 # sent_id = TRDE-CS-V03-0026
 # text = Keine Ahnung ich muss ehrlich sagen, ich bin schon verantwortungsbewusst zaten hep öyleydi also ich war immer verantwortungsbewusst.
-1	Keine	kein	DET	_	Case=Nom|Definite=Ind|Gender=Fem|Number=Sing|Polarity=Neg|PronType=Neg	2	det	_	CSID=DE|Lang=de
+1	Keine	kein	DET	_	Case=Nom|Definite=Ind|Gender=Fem|Number=Sing|PronType=Neg	2	det	_	CSID=DE|Lang=de
 2	Ahnung	Ahnung	NOUN	_	Case=Nom|Gender=Fem|Number=Sing	6	parataxis	_	CSID=DE|Lang=de
 3	ich	ich	PRON	_	Case=Nom|Gender=Neut|Number=Sing|Person=1|PronType=Prs	6	nsubj	_	CSID=DE|Lang=de
 4	muss	müssen	AUX	_	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	6	aux	_	CSID=DE|Lang=de
@@ -9482,7 +9482,7 @@
 13	çünkü	çünkü	SCONJ	_	_	15	mark	_	CSID=TR|Lang=tr
 14	ich	ich	PRON	_	Case=Nom|Gender=Neut|Number=Sing|Person=1|PronType=Prs	15	nsubj	_	CSID=DE|Lang=de
 15	habe	haben	VERB	_	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	3	parataxis	_	CSID=DE|Lang=de
-16	keinen	kein	DET	_	Case=Acc|Definite=Ind|Gender=Masc|Number=Sing|Polarity=Neg|PronType=Neg	17	det	_	CSID=DE|Lang=de
+16	keinen	kein	DET	_	Case=Acc|Definite=Ind|Gender=Masc|Number=Sing|PronType=Neg	17	det	_	CSID=DE|Lang=de
 17	Schlafrhythmus	Schlafrhythmus	NOUN	_	Case=Acc|Gender=Masc|Number=Sing	15	obj	_	CSID=DE|Lang=de
 18	mehr	mehr	ADV	_	_	15	advmod	_	CSID=DE|Lang=de|SpaceAfter=No
 19	.	.	PUNCT	_	_	3	punct	_	CSID=OTHER
@@ -10638,7 +10638,7 @@
 18	das	der	DET	_	Case=Nom|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	23	nsubj	_	CSID=DE|Lang=de
 19	war	sein	AUX	_	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	23	cop	_	CSID=DE|Lang=de
 20	ja	ja	ADV	_	_	23	advmod	_	CSID=DE|Lang=de
-21	keine	kein	DET	_	Case=Nom|Definite=Ind|Gender=Fem|Number=Sing|Polarity=Neg|PronType=Neg	23	det	_	CSID=DE|Lang=de
+21	keine	kein	DET	_	Case=Nom|Definite=Ind|Gender=Fem|Number=Sing|PronType=Neg	23	det	_	CSID=DE|Lang=de
 22	richtige	richtig	ADJ	_	Case=Nom|Gender=Fem|Number=Sing	23	amod	_	CSID=DE|Lang=de
 23	Umstellung	Umstellung	NOUN	_	Case=Nom|Gender=Fem|Number=Sing	10	parataxis	_	CSID=DE|Lang=de
 24	sowas	sowas	PRON	_	Case=Acc|Number=Sing|PronType=Ind	31	obj	_	CSID=DE|Lang=de
@@ -11674,7 +11674,7 @@
 9	das	der	DET	_	Case=Nom|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	10	det	_	CSID=DE|Lang=de
 10	Programmieren	Programmieren	NOUN	_	Case=Dat|Gender=Neut|Number=Sing	3	parataxis	_	CSID=DE|Lang=de
 11	und	und	CCONJ	_	_	14	cc	_	CSID=DE|Lang=de
-12	keine	kein	DET	_	Case=Nom|Definite=Ind|Gender=Fem|Number=Sing|Polarity=Neg|PronType=Neg	13	det	_	CSID=DE|Lang=de
+12	keine	kein	DET	_	Case=Nom|Definite=Ind|Gender=Fem|Number=Sing|PronType=Neg	13	det	_	CSID=DE|Lang=de
 13	Ahnung	Ahnung	NOUN	_	Case=Nom|Gender=Fem|Number=Sing	14	nmod	_	CSID=DE|Lang=de
 14	was	was	PRON	_	Case=Nom|Number=Sing	10	conj	_	CSID=DE|Lang=de|SpaceAfter=No
 15	.	.	PUNCT	_	_	3	punct	_	CSID=OTHER
@@ -12319,7 +12319,7 @@
 15	so	so	ADV	_	_	16	advmod	_	CSID=DE|Lang=de
 16	rumgemacht	rummachen	VERB	_	VerbForm=Part	11	conj	_	CSID=DE|Lang=de
 17	und	und	CCONJ	_	_	20	cc	_	CSID=DE|Lang=de
-18	keine	kein	DET	_	Case=Nom|Definite=Ind|Gender=Fem|Number=Sing|Polarity=Neg|PronType=Neg	19	det	_	CSID=DE|Lang=de
+18	keine	kein	DET	_	Case=Nom|Definite=Ind|Gender=Fem|Number=Sing|PronType=Neg	19	det	_	CSID=DE|Lang=de
 19	Ahnung	Ahnung	NOUN	_	Case=Nom|Gender=Fem|Number=Sing	20	nmod	_	CSID=DE|Lang=de
 20	was	was	PRON	_	Case=Nom|Number=Sing	16	conj	_	CSID=DE|Lang=de
 21	und	und	CCONJ	_	_	25	cc	_	CSID=DE|Lang=de
@@ -12723,7 +12723,7 @@
 2	der	der	PRON	_	Case=Nom|Gender=Masc|Number=Sing|PronType=Dem	6	nsubj	_	CSID=DE|Lang=de
 3	war	sein	AUX	_	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	6	cop	_	CSID=DE|Lang=de
 4	auch	auch	ADV	_	_	6	advmod	_	CSID=DE|Lang=de
-5	kein	kein	PRON	_	Case=Nom|Gender=Neut|Number=Sing|Polarity=Neg|PronType=Neg	6	nmod	_	CSID=DE|Lang=de
+5	kein	kein	PRON	_	Case=Nom|Gender=Neut|Number=Sing|PronType=Neg	6	nmod	_	CSID=DE|Lang=de
 6	Dings	Ding	NOUN	_	Case=Nom|Gender=Neut|Number=Sing	0	root	_	CSID=DE|Lang=de
 7	yazar	yazar	NOUN	_	Case=Nom|Number=Sing	6	dislocated	_	CSID=TR|Lang=tr|DislocateHead=6
 8	sondern	sondern	CCONJ	_	_	10	cc	_	CSID=DE|Lang=de
@@ -13002,7 +13002,7 @@
 20	oder	oder	CCONJ	_	_	21	cc	_	CSID=DE|Lang=de
 21	so	so	ADV	_	_	19	conj	_	CSID=DE|Lang=de|SpaceAfter=No
 22	,	,	PUNCT	_	_	24	punct	_	CSID=OTHER
-23	keine	kein	DET	_	Case=Nom|Definite=Ind|Gender=Fem|Number=Sing|Polarity=Neg|PronType=Neg	24	det	_	CSID=DE|Lang=de
+23	keine	kein	DET	_	Case=Nom|Definite=Ind|Gender=Fem|Number=Sing|PronType=Neg	24	det	_	CSID=DE|Lang=de
 24	Ahnung	Ahnung	NOUN	_	Case=Nom|Gender=Fem|Number=Sing	14	parataxis:discourse	_	CSID=DE|Lang=de|SpaceAfter=No
 25	.	.	PUNCT	_	_	14	punct	_	CSID=OTHER
 

--- a/qtd_sagt-ud-train.conllu
+++ b/qtd_sagt-ud-train.conllu
@@ -717,7 +717,7 @@
 3	wenn	wenn	SCONJ	_	_	8	mark	_	CSID=DE|Lang=de
 4	du	du	PRON	_	Case=Nom|Number=Sing|Person=2|PronType=Prs	8	nsubj	_	CSID=DE|Lang=de
 5	jetzt	jetzt	ADV	_	_	8	advmod	_	CSID=DE|Lang=de
-6	kein	kein	DET	_	Case=Acc|Definite=Ind|Gender=Masc|Number=Sing|Polarity=Neg|PronType=Neg	7	det	_	CSID=DE|Lang=de
+6	kein	kein	DET	_	Case=Acc|Definite=Ind|Gender=Masc|Number=Sing|PronType=Neg	7	det	_	CSID=DE|Lang=de
 7	Sport	Sport	PROPN	_	Case=Acc|Gender=Masc|Number=Sing	8	obj	_	CSID=DE|Lang=de
 8	machst	machen	VERB	_	Mood=Ind|Number=Sing|Person=2|Tense=Pres|VerbForm=Fin	0	root	_	CSID=DE|Lang=de
 9	ja	ja	INTJ	_	_	18	discourse	_	CSID=DE|Lang=de
@@ -735,7 +735,7 @@
 21	uff	uff	INTJ	_	_	23	discourse	_	CSID=DE|Lang=de
 22	ich	ich	PRON	_	Case=Nom|Number=Sing|Person=1|PronType=Prs	23	nsubj	_	CSID=DE|Lang=de
 23	habe	haben	VERB	_	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	18	conj	_	CSID=DE|Lang=de
-24	kein	kein	DET	_	Case=Acc|Definite=Ind|Gender=Masc|Number=Sing|Polarity=Neg|PronType=Neg	25	det	_	CSID=DE|Lang=de
+24	kein	kein	DET	_	Case=Acc|Definite=Ind|Gender=Masc|Number=Sing|PronType=Neg	25	det	_	CSID=DE|Lang=de
 25	Bock	Bock	PROPN	_	Case=Acc|Gender=Masc|Number=Sing	23	obj	_	CSID=DE|Lang=de|SpaceAfter=No
 26	.	.	PUNCT	_	_	8	punct	_	CSID=OTHER
 
@@ -1372,7 +1372,7 @@
 21	dem	der	DET	_	Case=Dat|Definite=Def|Gender=Neut|Number=Sing|PronType=Art	22	det	_	CSID=DE|Lang=de
 22	Beispiel	Beispiel	NOUN	_	Case=Dat|Gender=Neut|Number=Sing	26	obl	_	CSID=DE|Lang=de
 23	alle	alle	PRON	_	Case=Nom|Gender=Fem|Number=Sing|PronType=Ind	26	nsubj	_	CSID=DE|Lang=de
-24	kein	kein	DET	_	Case=Acc|Definite=Ind|Gender=Masc|Number=Sing|Polarity=Neg|PronType=Neg	25	det	_	CSID=DE|Lang=de
+24	kein	kein	DET	_	Case=Acc|Definite=Ind|Gender=Masc|Number=Sing|PronType=Neg	25	det	_	CSID=DE|Lang=de
 25	Fußball	Fußball	NOUN	_	Case=Acc|Gender=Masc|Number=Sing	26	obj	_	CSID=DE|Lang=de
 26	angucken	angucken	VERB	_	VerbForm=Inf	8	ccomp	_	CSID=DE|Lang=de
 27	ama	ama	CCONJ	_	_	32	cc	_	CSID=TR|Lang=tr
@@ -1691,7 +1691,7 @@
 6	nur	nur	ADV	_	_	7	advmod	_	CSID=DE|Lang=de
 7	dasaß	dasitzen	VERB	_	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	0	root	_	CSID=DE|Lang=de
 8	und	und	CCONJ	_	_	12	cc	_	CSID=DE|Lang=de
-9	keine	kein	DET	_	Case=Nom|Definite=Ind|Gender=Fem|Number=Sing|Polarity=Neg|PronType=Neg	10	det	_	CSID=DE|Lang=de
+9	keine	kein	DET	_	Case=Nom|Definite=Ind|Gender=Fem|Number=Sing|PronType=Neg	10	det	_	CSID=DE|Lang=de
 10	Aufgaben	Aufgabe	NOUN	_	Case=Nom|Gender=Fem|Number=Plur	12	obj	_	CSID=DE|Lang=de
 11	äh	äh	INTJ	_	_	12	discourse	_	CSID=DE|Lang=de
 12	machen	machen	VERB	_	VerbForm=Inf	7	conj	_	CSID=DE|Lang=de
@@ -3540,7 +3540,7 @@
 2	habe	haben	VERB	_	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	0	root	_	CSID=DE|Lang=de
 3	sowas	sowas	PRON	_	Case=Nom|Number=Sing|PronType=Ind	6	nmod	_	CSID=DE|Lang=de
 4	von	von	ADP	_	_	3	fixed	_	CSID=DE|Lang=de
-5	kein	kein	DET	_	Case=Nom|Definite=Ind|Gender=Neut|Number=Sing|Polarity=Neg|PronType=Neg	6	det	_	CSID=DE|Lang=de
+5	kein	kein	DET	_	Case=Nom|Definite=Ind|Gender=Neut|Number=Sing|PronType=Neg	6	det	_	CSID=DE|Lang=de
 6	Talent	Talent	NOUN	_	Case=Nom|Gender=Neut|Number=Sing	2	obj	_	CSID=DE|Lang=de
 7	in	in	ADP	_	_	8	case	_	CSID=DE|Lang=de
 8	Englisch	Englisch	NOUN	_	Case=Dat|Gender=Neut|Number=Sing	2	obl	_	CSID=DE|Lang=de
@@ -3695,7 +3695,7 @@
 9	sowas	sowas	PRON	_	Case=Acc|Number=Sing|PronType=Ind	7	conj	_	CSID=DE|Lang=de
 10	machen	machen	VERB	_	VerbForm=Inf	0	root	_	CSID=DE|Lang=de
 11	aber	aber	CCONJ	_	_	20	cc	_	CSID=DE|Lang=de
-12	keine	kein	DET	_	Case=Acc|Definite=Ind|Gender=Fem|Number=Sing|Polarity=Neg|PronType=Neg	13	det	_	CSID=DE|Lang=de
+12	keine	kein	DET	_	Case=Acc|Definite=Ind|Gender=Fem|Number=Sing|PronType=Neg	13	det	_	CSID=DE|Lang=de
 13	Ahnung	Ahnung	NOUN	_	Case=Acc|Gender=Fem|Number=Sing	20	obj	_	CSID=DE|Lang=de
 14	hani	hani	ADV	_	_	20	discourse	_	CSID=TR|Lang=tr
 15	ich	ich	PRON	_	Case=Nom|Number=Sing|Person=1|PronType=Prs	20	nsubj	_	CSID=DE|Lang=de
@@ -3735,7 +3735,7 @@
 
 # sent_id = TRDE-CS-C14-0005
 # text = Keine Ahnung o zamanlar als ich das angefangen hatte, wollte ich wissen wo ich damit arbeiten kann.
-1	Keine	kein	DET	_	Case=Nom|Definite=Ind|Gender=Fem|Number=Sing|Polarity=Neg|PronType=Neg	2	det	_	CSID=DE|Lang=de
+1	Keine	kein	DET	_	Case=Nom|Definite=Ind|Gender=Fem|Number=Sing|PronType=Neg	2	det	_	CSID=DE|Lang=de
 2	Ahnung	Ahnung	NOUN	_	Case=Nom|Gender=Fem|Number=Sing	8	obl	_	CSID=DE|Lang=de
 3	o	o	PRON	_	Case=Nom|Number=Sing|Person=3|PronType=Prs	4	det	_	CSID=TR|Lang=tr
 4	zamanlar	zaman	NOUN	_	Case=Nom|Number=Plur	8	obl	_	CSID=TR|Lang=tr
@@ -4162,7 +4162,7 @@
 21	irgendwas	irgendwas	PRON	_	Case=Nom|Gender=Neut|Number=Sing|PronType=Ind	15	conj	_	CSID=DE|Lang=de
 22	ich	ich	PRON	_	Case=Nom|Number=Sing|Person=1|PronType=Prs	28	nsubj	_	CSID=DE|Lang=de
 23	habe	haben	AUX	_	Mood=Ind|Number=Sing|Person=1|Tense=Pres|VerbForm=Fin	28	aux	_	CSID=DE|Lang=de
-24	keines	kein	PRON	_	Case=Acc|Gender=Fem|Number=Sing|Polarity=Neg|PronType=Neg	27	nmod	_	CSID=DE|Lang=de
+24	keines	kein	PRON	_	Case=Acc|Gender=Fem|Number=Sing|PronType=Neg	27	nmod	_	CSID=DE|Lang=de
 25	von	von	ADP	_	_	27	case	_	CSID=DE|Lang=de
 26	den	der	DET	_	Case=Acc|Definite=Def|Gender=Fem|Number=Plur|PronType=Art	27	det	_	CSID=DE|Lang=de
 27	Sachen	Sache	NOUN	_	Case=Acc|Gender=Fem|Number=Plur	28	obj	_	CSID=DE|Lang=de
@@ -4178,7 +4178,7 @@
 5	ich	ich	PRON	_	Case=Nom|Number=Sing|Person=1|PronType=Prs	6	nsubj	_	CSID=DE|Lang=de
 6	hatte	haben	VERB	_	Mood=Ind|Number=Sing|Person=1|Tense=Past|VerbForm=Fin	3	conj	_	CSID=DE|Lang=de
 7	gar	gar	ADV	_	_	8	advmod	_	CSID=DE|Lang=de
-8	keine	kein	DET	_	Case=Acc|Definite=Ind|Gender=Fem|Number=Sing|Polarity=Neg|PronType=Neg	9	det	_	CSID=DE|Lang=de
+8	keine	kein	DET	_	Case=Acc|Definite=Ind|Gender=Fem|Number=Sing|PronType=Neg	9	det	_	CSID=DE|Lang=de
 9	Ferien	Ferien	NOUN	_	Case=Acc|Gender=Fem|Number=Plur	6	obj	_	CSID=DE|Lang=de
 10	richtig	richtig	ADJ	_	_	6	advmod	_	CSID=DE|Lang=de|SpaceAfter=No
 11	.	.	PUNCT	_	_	3	punct	_	CSID=OTHER
@@ -4983,7 +4983,7 @@
 15	bir	bir	DET	_	Definite=Ind	16	det	_	CSID=TR|Lang=tr
 16	şekilde	şekil	NOUN	_	Case=Loc|Number=Sing	17	obl	_	CSID=TR|Lang=tr
 17	yapamadım	yap	VERB	_	Aspect=Perf|Evident=Fh|Mood=Pot|Number=Sing|Person=1|Polarity=Neg|Tense=Past	5	conj	_	CSID=TR|Lang=tr
-18	keine	kein	DET	_	Case=Acc|Definite=Ind|Gender=Fem|Number=Sing|Polarity=Neg|PronType=Neg	19	det	_	CSID=DE|Lang=de
+18	keine	kein	DET	_	Case=Acc|Definite=Ind|Gender=Fem|Number=Sing|PronType=Neg	19	det	_	CSID=DE|Lang=de
 19	Ahnung	Ahnung	NOUN	_	Case=Acc|Gender=Fem|Number=Sing	17	advcl	_	CSID=DE|Lang=de
 20	wieso	wieso	ADV	_	_	19	advmod	_	CSID=DE|Lang=de|SpaceAfter=No
 21	,	,	PUNCT	_	_	29	punct	_	CSID=OTHER
@@ -5602,7 +5602,7 @@
 # text = Mesela, keine Ahnung irgendwelche Dinger so inşaatçı aus der Familie oder so?
 1	Mesela	mesela	ADV	_	_	6	advmod	_	CSID=TR|Lang=tr|SpaceAfter=No
 2	,	,	PUNCT	_	_	1	punct	_	CSID=OTHER
-3	keine	kein	DET	_	Case=Nom|Definite=Ind|Gender=Fem|Number=Sing|Polarity=Neg|PronType=Neg	4	det	_	CSID=DE|Lang=de
+3	keine	kein	DET	_	Case=Nom|Definite=Ind|Gender=Fem|Number=Sing|PronType=Neg	4	det	_	CSID=DE|Lang=de
 4	Ahnung	Ahnung	NOUN	_	Case=Nom|Gender=Fem|Number=Sing	6	nmod	_	CSID=DE|Lang=de
 5	irgendwelche	irgendwelch	PRON	_	Case=Nom|Gender=Neut|Number=Plur|PronType=Ind	6	nmod	_	CSID=DE|Lang=de
 6	Dinger	Ding	NOUN	_	Case=Nom|Gender=Neut|Number=Plur	0	root	_	CSID=DE|Lang=de
@@ -5966,7 +5966,7 @@
 6	die	der	PRON	_	Case=Nom|Gender=Fem|Number=Plur|PronType=Rel	3	appos	_	CSID=DE|Lang=de
 7	haben	haben	VERB	_	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	CSID=DE|Lang=de
 8	halt	halt	ADV	_	_	7	advmod	_	CSID=DE|Lang=de
-9	keine	kein	DET	_	Case=Nom|Definite=Ind|Gender=Fem|Number=Sing|Polarity=Neg|PronType=Neg	11	det	_	CSID=DE|Lang=de
+9	keine	kein	DET	_	Case=Nom|Definite=Ind|Gender=Fem|Number=Sing|PronType=Neg	11	det	_	CSID=DE|Lang=de
 10	natürlichen	natürlich	ADJ	_	Case=Acc|Gender=Masc|Number=Sing	11	amod	_	CSID=DE|Lang=de
 11	Feinde	Feind	NOUN	_	Case=Acc|Gender=Masc|Number=Plur	7	obj	_	CSID=DE|Lang=de
 12	auf	auf	ADP	_	_	14	case	_	CSID=DE|Lang=de
@@ -6040,7 +6040,7 @@
 2	,	,	PUNCT	_	_	4	punct	_	CSID=OTHER
 3	hoffentlich	hoffentlich	ADV	_	_	4	advmod	_	CSID=DE|Lang=de
 4	stirbt	sterben	VERB	_	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	1	conj	_	CSID=DE|Lang=de
-5	keiner	kein	PRON	_	Case=Nom|Gender=Masc|Number=Sing|Polarity=Neg|PronType=Neg	4	nsubj	_	CSID=DE|Lang=de
+5	keiner	kein	PRON	_	Case=Nom|Gender=Masc|Number=Sing|PronType=Neg	4	nsubj	_	CSID=DE|Lang=de
 6	in	in	ADP	_	_	9	case	_	CSID=DE|Lang=de
 7	dem	der	DET	_	Case=Dat|Definite=Def|Gender=Masc|Number=Sing|PronType=Art	9	det	_	CSID=DE|Lang=de
 8	türkischen	türkisch	ADJ	_	Case=Dat|Gender=Masc|Number=Sing	9	amod	_	CSID=DE|Lang=de
@@ -6188,7 +6188,7 @@
 9	da	da	ADV	_	_	10	advmod	_	CSID=DE|Lang=de
 10	schauen	schauen	VERB	_	Mood=Ind|Number=Plur|Person=3|Tense=Pres|VerbForm=Fin	4	acl	_	CSID=DE|Lang=de|SpaceAfter=No
 11	,	,	PUNCT	_	_	18	punct	_	CSID=OTHER
-12	keine	kein	DET	_	Case=Nom|Definite=Ind|Gender=Fem|Number=Sing|Polarity=Neg|PronType=Neg	13	det	_	CSID=DE|Lang=de
+12	keine	kein	DET	_	Case=Nom|Definite=Ind|Gender=Fem|Number=Sing|PronType=Neg	13	det	_	CSID=DE|Lang=de
 13	Ahnung	Ahnung	NOUN	_	Case=Nom|Gender=Fem|Number=Sing	15	nmod	_	CSID=DE|Lang=de
 14	wie	wie	ADP	_	_	15	case	_	CSID=DE|Lang=de
 15	viele	viel	PRON	_	Case=Nom|Gender=Neut|Number=Plur|PronType=Ind	18	nmod	_	CSID=DE|Lang=de|SpaceAfter=No
@@ -6287,7 +6287,7 @@
 1	Ja	ja	INTJ	_	_	2	discourse	_	CSID=DE|Lang=de
 2	wirklich	wirklich	ADV	_	_	5	advmod	_	CSID=DE|Lang=de|SpaceAfter=No
 3	,	,	PUNCT	_	_	2	punct	_	CSID=OTHER
-4	keiner	kein	PRON	_	Case=Nom|Gender=Masc|Number=Sing|Polarity=Neg|PronType=Neg	5	nsubj	_	CSID=DE|Lang=de
+4	keiner	kein	PRON	_	Case=Nom|Gender=Masc|Number=Sing|PronType=Neg	5	nsubj	_	CSID=DE|Lang=de
 5	hält	halten	VERB	_	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	CSID=DE|Lang=de
 6	zu	zu	ADP	_	_	8	case	_	CSID=DE|Lang=de
 7	den	der	DET	_	Case=Dat|Definite=Def|Gender=Fem|Number=Plur|PronType=Art	8	det	_	CSID=DE|Lang=de
@@ -6312,7 +6312,7 @@
 3	beraber	beraber	ADV	_	_	8	advmod	_	CSID=TR|Lang=tr
 4	haben	haben	AUX	_	Mood=Ind|Number=Plur|Person=1|Tense=Pres|VerbForm=Fin	8	aux	_	CSID=DE|Lang=de
 5	wir	wir	PRON	_	Case=Nom|Number=Plur|Person=1|PronType=Prs	8	nsubj	_	CSID=DE|Lang=de
-6	keine	kein	PRON	_	Case=Acc|Number=Plur|Polarity=Neg|PronType=Neg	7	nmod	_	CSID=DE|Lang=de
+6	keine	kein	PRON	_	Case=Acc|Number=Plur|PronType=Neg	7	nmod	_	CSID=DE|Lang=de
 7	Filme	Film	NOUN	_	Case=Acc|Gender=Masc|Number=Plur	8	obj	_	CSID=DE|Lang=de
 8	angeschaut	anschauen	VERB	_	VerbForm=Part	0	root	_	CSID=DE|Lang=de|SpaceAfter=No
 9	.	.	PUNCT	_	_	8	punct	_	CSID=OTHER
@@ -6467,7 +6467,7 @@
 
 # sent_id = TRDE-CS-S14-0041
 # text = Keine Ahnung, die sollen ihm nicht so einen Normalen geben Alter, ünlü bir şey versinler, mehrere Filme will ich mit ihm haben.
-1	Keine	kein	DET	_	Case=Acc|Definite=Ind|Gender=Fem|Number=Sing|Polarity=Neg|PronType=Neg	2	det	_	CSID=DE|Lang=de
+1	Keine	kein	DET	_	Case=Acc|Definite=Ind|Gender=Fem|Number=Sing|PronType=Neg	2	det	_	CSID=DE|Lang=de
 2	Ahnung	Ahnung	NOUN	_	Case=Nom|Gender=Fem|Number=Sing	0	root	_	CSID=DE|Lang=de|SpaceAfter=No
 3	,	,	PUNCT	_	_	11	punct	_	CSID=OTHER
 4	die	der	PRON	_	Case=Nom|Gender=Fem|Number=Plur|PronType=Dem	11	nsubj	_	CSID=DE|Lang=de
@@ -7850,7 +7850,7 @@
 12	ich	ich	PRON	_	Case=Nom|Number=Sing|Person=1|PronType=Prs	11	nsubj	_	CSID=DE|Lang=de
 13	ja	ja	ADV	_	_	11	advmod	_	CSID=DE|Lang=de
 14	überhaupt	überhaupt	ADV	_	_	16	advmod	_	CSID=DE|Lang=de
-15	keine	kein	DET	_	Case=Acc|Definite=Ind|Gender=Fem|Number=Sing|Polarity=Neg|PronType=Neg	16	det	_	CSID=DE|Lang=de
+15	keine	kein	DET	_	Case=Acc|Definite=Ind|Gender=Fem|Number=Sing|PronType=Neg	16	det	_	CSID=DE|Lang=de
 16	Lust	Lust	NOUN	_	Case=Acc|Gender=Fem|Number=Sing	11	obj	_	CSID=DE|Lang=de|SpaceAfter=No
 17	.	.	PUNCT	_	_	5	punct	_	CSID=OTHER
 
@@ -7930,7 +7930,7 @@
 # text = Hat man keine Lust, değil mi?
 1	Hat	haben	VERB	_	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	0	root	_	CSID=DE|Lang=de
 2	man	man	PRON	_	Case=Nom|Number=Sing|PronType=Ind	1	nsubj	_	CSID=DE|Lang=de
-3	keine	kein	DET	_	Case=Acc|Definite=Ind|Gender=Fem|Number=Sing|Polarity=Neg|PronType=Neg	4	det	_	CSID=DE|Lang=de
+3	keine	kein	DET	_	Case=Acc|Definite=Ind|Gender=Fem|Number=Sing|PronType=Neg	4	det	_	CSID=DE|Lang=de
 4	Lust	Lust	NOUN	_	Case=Acc|Gender=Fem|Number=Sing	1	obj	_	CSID=DE|Lang=de|SpaceAfter=No
 5	,	,	PUNCT	_	_	6	punct	_	CSID=OTHER
 6	değil	değil	PART	_	_	1	parataxis:discourse	_	CSID=TR|Lang=tr
@@ -7967,7 +7967,7 @@
 26	ich	ich	PRON	_	Case=Nom|Number=Sing|Person=1|PronType=Prs	25	nsubj	_	CSID=DE|Lang=de
 27	irgendwie	irgendwie	ADV	_	_	25	advmod	_	CSID=DE|Lang=de
 28	gar	gar	ADV	_	_	29	advmod	_	CSID=DE|Lang=de
-29	kein	kein	PRON	_	Case=Acc|Gender=Masc|Number=Sing|Polarity=Neg|PronType=Neg	30	nmod	_	CSID=DE|Lang=de
+29	kein	kein	PRON	_	Case=Acc|Gender=Masc|Number=Sing|PronType=Neg	30	nmod	_	CSID=DE|Lang=de
 30	Bock	Bock	NOUN	_	Case=Acc|Gender=Masc|Number=Sing	25	obj	_	CSID=DE|Lang=de
 31	mehr	mehr	ADV	_	_	25	advmod	_	CSID=DE|Lang=de|SpaceAfter=No
 32	.	.	PUNCT	_	_	5	punct	_	CSID=OTHER
@@ -8529,7 +8529,7 @@
 4	vorbei	vorbei	ADV	_	_	8	advcl	_	CSID=DE|Lang=de
 5	ist	sein	AUX	_	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	4	cop	_	CSID=DE|Lang=de|SpaceAfter=No
 6	,	,	PUNCT	_	_	4	punct	_	CSID=OTHER
-7	keinen	kein	PRON	_	Case=Acc|Gender=Masc|Number=Sing|Polarity=Neg|PronType=Neg	8	obj	_	CSID=DE|Lang=de
+7	keinen	kein	PRON	_	Case=Acc|Gender=Masc|Number=Sing|PronType=Neg	8	obj	_	CSID=DE|Lang=de
 8	juckt	jucken	VERB	_	Mood=Ind|Number=Sing|Person=3|Tense=Pres	0	root	_	CSID=DE|Lang=de
 9	es	es	PRON	_	Case=Acc|Gender=Neut|Number=Sing|Person=3|PronType=Prs	8	expl	_	CSID=DE|Lang=de
 10	mehr	mehr	ADV	_	_	8	advmod	_	CSID=DE|Lang=de
@@ -9920,7 +9920,7 @@
 # text = Okay, kein Bock mehr, anderes Thema gibi.
 1	Okay	okay	INTJ	_	_	4	discourse	_	CSID=DE|Lang=de|SpaceAfter=No
 2	,	,	PUNCT	_	_	1	punct	_	CSID=OTHER
-3	kein	kein	PRON	_	Case=Nom|Gender=Masc|Number=Sing|Polarity=Neg|PronType=Neg	4	nmod	_	CSID=DE|Lang=de
+3	kein	kein	PRON	_	Case=Nom|Gender=Masc|Number=Sing|PronType=Neg	4	nmod	_	CSID=DE|Lang=de
 4	Bock	Bock	NOUN	_	Case=Nom|Gender=Masc|Number=Sing	0	root	_	CSID=DE|Lang=de
 5	mehr	mehr	ADV	_	_	4	advmod	_	CSID=DE|Lang=de|SpaceAfter=No
 6	,	,	PUNCT	_	_	8	punct	_	CSID=OTHER
@@ -10967,7 +10967,7 @@
 10	herhalde	herhalde	ADV	_	_	9	advmod	_	CSID=TR|Lang=tr
 11	der	der	PRON	_	Case=Nom|Gender=Masc|Number=Sing|PronType=Dem	12	nsubj	_	CSID=DE|Lang=de
 12	hat	haben	VERB	_	Mood=Ind|Number=Sing|Person=3|Tense=Pres|VerbForm=Fin	9	conj	_	CSID=DE|Lang=de
-13	kein	kein	PRON	_	Case=Acc|Gender=Masc|Number=Sing|Polarity=Neg|PronType=Neg	14	nmod	_	CSID=DE|Lang=de
+13	kein	kein	PRON	_	Case=Acc|Gender=Masc|Number=Sing|PronType=Neg	14	nmod	_	CSID=DE|Lang=de
 14	Bock	Bock	NOUN	_	Case=Acc|Gender=Masc|Number=Sing	12	obj	_	CSID=DE|Lang=de
 15	auf	auf	ADP	_	_	16	case	_	CSID=DE|Lang=de
 16	mich	ich	PRON	_	Case=Acc|Number=Sing|Person=1|PronType=Prs	14	nmod	_	CSID=DE|Lang=de|SpaceAfter=No
@@ -11215,7 +11215,7 @@
 5	mı	mi	AUX	_	Number=Sing|Person=3	4	aux:q	_	CSID=TR|Lang=tr
 6	var	var	ADJ	_	_	0	root	_	CSID=TR|Lang=tr
 7	sowie	sowie	ADV	_	_	12	advmod	_	CSID=DE|Lang=de
-8	keine	kein	DET	_	Case=Nom|Definite=Ind|Gender=Fem|Number=Sing|Polarity=Neg|PronType=Neg	9	det	_	CSID=DE|Lang=de
+8	keine	kein	DET	_	Case=Nom|Definite=Ind|Gender=Fem|Number=Sing|PronType=Neg	9	det	_	CSID=DE|Lang=de
 9	Ahnung	Ahnung	NOUN	_	Case=Nom|Gender=Fem|Number=Sing	12	obl	_	CSID=DE|Lang=de
 10	so	so	ADV	_	_	12	discourse	_	CSID=DE|Lang=de
 11	Vampire	Vampir	NOUN	_	Case=Nom|Gender=Masc|Number=Plur	12	nmod	_	CSID=DE|Lang=de
@@ -11784,7 +11784,7 @@
 8	balta	balta	NOUN	_	Case=Nom|Number=Sing	6	nsubj	_	CSID=TR|Lang=tr
 9	mit	mit	ADP	_	_	10	case	_	CSID=DE|Lang=de
 10	büyü	büyü	NOUN	_	Case=Nom|Number=Sing	8	obl	_	CSID=TR|Lang=tr
-11	keine	kein	DET	_	Case=Nom|Definite=Ind|Gender=Fem|Number=Sing|Polarity=Neg|PronType=Neg	12	det	_	CSID=DE|Lang=de
+11	keine	kein	DET	_	Case=Nom|Definite=Ind|Gender=Fem|Number=Sing|PronType=Neg	12	det	_	CSID=DE|Lang=de
 12	Ahnung	Ahnung	NOUN	_	Case=Nom|Gender=Fem|Number=Sing	6	conj	_	CSID=DE|Lang=de|SpaceAfter=No
 13	?	?	PUNCT	_	_	6	punct	_	CSID=OTHER
 

--- a/stats.xml
+++ b/stats.xml
@@ -80,7 +80,7 @@
     <feat name="Person[psor]" value="1" upos="ADP,NOUN,PRON,PROPN,VERB">408</feat><!-- benim, dediğim, bizim, hoşuma, yapmam, kendimi, aklıma, annem, annemle, arkadaşım -->
     <feat name="Person[psor]" value="2" upos="ADP,NOUN,PRON,PROPN,VERB">183</feat><!-- üzerine, geçen, istediğin, kendin, yaptığın, hepsini, senin, bildiğin, hoşuna, Kundelerin -->
     <feat name="Person[psor]" value="3" upos="ADP,NOUN,NUM,PRON,PROPN,VERB">509</feat><!-- şeyi, adı, içinde, hakkında, yemeği, burası, iyisi, adını, alakası, başında -->
-    <feat name="Polarity" value="Neg" upos="DET,PART,PRON,VERB">562</feat><!-- nicht, keine, bilmiyorum, kein, bilmem, gelmedi, etmeye, görmedim, istemiyorum, yapmıyorsun -->
+    <feat name="Polarity" value="Neg" upos="PART,VERB">510</feat><!-- nicht, bilmiyorum, bilmem, gelmedi, etmeye, görmedim, istemiyorum, yapmıyorsun, başlamadım, duymadım -->
     <feat name="Polarity" value="Pos" upos="VERB">1</feat><!-- gitti -->
     <feat name="Poss" value="Yes" upos="PRON">91</feat><!-- mein, meine, dein, meinem, meiner, unsere, meinen, deinen, seine, ihren -->
     <feat name="PronType" value="Art" upos="DET">968</feat><!-- dem, die, der, ein, das, eine, den, einen, einem, des -->


### PR DESCRIPTION
Since `Polarity` is no longer allowed with `PRON` or `DET` in German, tokens that had it and also declared `Lang=de` in MISC became invalid. The tokens are forms of the negative pronoun/determiner _kein_, which already has `PronType=Neg`, so no information is lost when the `Polarity` feature is removed. This PR makes the treebank valid again.